### PR TITLE
initialize tag variable

### DIFF
--- a/models/seqgan.py
+++ b/models/seqgan.py
@@ -430,6 +430,7 @@ class SeqGAN(chainer.Chain):
 
         :return: rewards (batch_size)
         """
+        tag = None
         if len(args) == 4:
             samples, given, dis, rollout_num = args
         elif len(args) == 5:


### PR DESCRIPTION
When length of args on roll_out is smaller than 6, tag variable is undefined,
and it causes a error.
